### PR TITLE
Add LikeChain related contracts

### DIFF
--- a/contracts/SignatureCheckerImpl.sol
+++ b/contracts/SignatureCheckerImpl.sol
@@ -29,8 +29,6 @@ contract SignatureCheckerImpl {
     }
 
     struct TransferDelegatedData {
-        address contractAddr;
-        string method;
         address to;
         uint256 value;
         uint256 maxReward;
@@ -38,8 +36,6 @@ contract SignatureCheckerImpl {
     }
 
     struct TransferAndCallDelegatedData {
-        address contractAddr;
-        string method;
         address to;
         uint256 value;
         bytes data;
@@ -48,8 +44,6 @@ contract SignatureCheckerImpl {
     }
 
     struct TransferMultipleDelegatedData {
-        address contractAddr;
-        string method;
         address[] addrs;
         uint256[] values;
         uint256 maxReward;
@@ -61,15 +55,15 @@ contract SignatureCheckerImpl {
     );
 
     bytes32 constant TRANSFER_DELEGATED_DATA_TYPEHASH = keccak256(
-        "TransferDelegatedData(address contractAddr,string method,address to,uint256 value,uint256 maxReward,uint256 nonce)"
+        "TransferDelegatedData(address to,uint256 value,uint256 maxReward,uint256 nonce)"
     );
 
     bytes32 constant TRANSFER_AND_CALL_DELEGATED_DATA_TYPEHASH = keccak256(
-        "TransferAndCallDelegatedData(address contractAddr,string method,address to,uint256 value,bytes data,uint256 maxReward,uint256 nonce)"
+        "TransferAndCallDelegatedData(address to,uint256 value,bytes data,uint256 maxReward,uint256 nonce)"
     );
 
     bytes32 constant TRANSFER_MULTIPLE_DELEGATED_DATA_TYPEHASH = keccak256(
-        "TransferMultipleDelegatedData(address contractAddr,string method,address[] addrs,uint256[] values,uint256 maxReward,uint256 nonce)"
+        "TransferMultipleDelegatedData(address[] addrs,uint256[] values,uint256 maxReward,uint256 nonce)"
     );
 
     bytes32 DOMAIN_SEPARATOR;
@@ -96,8 +90,6 @@ contract SignatureCheckerImpl {
     function hash(TransferDelegatedData data) internal pure returns (bytes32) {
         return keccak256(abi.encode(
             TRANSFER_DELEGATED_DATA_TYPEHASH,
-            data.contractAddr,
-            keccak256(bytes(data.method)),
             data.to,
             data.value,
             data.maxReward,
@@ -108,8 +100,6 @@ contract SignatureCheckerImpl {
     function hash(TransferAndCallDelegatedData data) internal pure returns (bytes32) {
         return keccak256(abi.encode(
             TRANSFER_AND_CALL_DELEGATED_DATA_TYPEHASH,
-            data.contractAddr,
-            keccak256(bytes(data.method)),
             data.to,
             data.value,
             keccak256(data.data),
@@ -123,8 +113,6 @@ contract SignatureCheckerImpl {
         bytes32 valuesHash = keccak256(abi.encodePacked(data.values));
         return keccak256(abi.encode(
             TRANSFER_MULTIPLE_DELEGATED_DATA_TYPEHASH,
-            data.contractAddr,
-            keccak256(bytes(data.method)),
             addrsHash,
             valuesHash,
             data.maxReward,
@@ -157,8 +145,6 @@ contract SignatureCheckerImpl {
             "\x19\x01",
             DOMAIN_SEPARATOR,
             hash(TransferDelegatedData({
-                contractAddr: msg.sender,
-                method: "transferDelegated",
                 to: _to,
                 value: _value,
                 maxReward: _maxReward,
@@ -185,8 +171,6 @@ contract SignatureCheckerImpl {
             "\x19\x01",
             DOMAIN_SEPARATOR,
             hash(TransferAndCallDelegatedData({
-                contractAddr: msg.sender,
-                method: "transferAndCallDelegated",
                 to: _to,
                 value: _value,
                 data: _data,
@@ -213,8 +197,6 @@ contract SignatureCheckerImpl {
             "\x19\x01",
             DOMAIN_SEPARATOR,
             hash(TransferMultipleDelegatedData({
-                contractAddr: msg.sender,
-                method: "transferMultipleDelegated",
                 addrs: _addrs,
                 values: _values,
                 maxReward: _maxReward,

--- a/contracts/SignatureCheckerImpl.sol
+++ b/contracts/SignatureCheckerImpl.sol
@@ -165,7 +165,10 @@ contract SignatureCheckerImpl {
                 nonce: _nonce
             }))
         ));
-        var (v, r, s) = _bytesToSignature(_signature);
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        (v, r, s) = _bytesToSignature(_signature);
         return 0x0 != _from && ecrecover(digest, v, r, s) == _from;
     }
 
@@ -191,7 +194,10 @@ contract SignatureCheckerImpl {
                 nonce: _nonce
             }))
         ));
-        var (v, r, s) = _bytesToSignature(_signature);
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        (v, r, s) = _bytesToSignature(_signature);
         return 0x0 != _from && ecrecover(digest, v, r, s) == _from;
     }
 
@@ -215,7 +221,10 @@ contract SignatureCheckerImpl {
                 nonce: _nonce
             }))
         ));
-        var (v, r, s) = _bytesToSignature(_signature);
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        (v, r, s) = _bytesToSignature(_signature);
         return 0x0 != _from && ecrecover(digest, v, r, s) == _from;
     }
 }

--- a/contracts/SignatureCheckerImpl.sol
+++ b/contracts/SignatureCheckerImpl.sol
@@ -15,11 +15,123 @@
 //    You should have received a copy of the GNU General Public License
 //    along with LikeCoin Smart Contract.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.24;
 
 import "./SignatureChecker.sol";
 
 contract SignatureCheckerImpl {
+
+    struct EIP712Domain {
+        string  name;
+        string  version;
+        uint256 chainId;
+        address verifyingContract;
+    }
+
+    struct TransferDelegatedData {
+        address contractAddr;
+        string method;
+        address to;
+        uint256 value;
+        uint256 maxReward;
+        uint256 nonce;
+    }
+
+    struct TransferAndCallDelegatedData {
+        address contractAddr;
+        string method;
+        address to;
+        uint256 value;
+        bytes data;
+        uint256 maxReward;
+        uint256 nonce;
+    }
+
+    struct TransferMultipleDelegatedData {
+        address contractAddr;
+        string method;
+        address[] addrs;
+        uint256[] values;
+        uint256 maxReward;
+        uint256 nonce;
+    }
+
+    bytes32 constant EIP712DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+    );
+
+    bytes32 constant TRANSFER_DELEGATED_DATA_TYPEHASH = keccak256(
+        "TransferDelegatedData(address contractAddr,string method,address to,uint256 value,uint256 maxReward,uint256 nonce)"
+    );
+
+    bytes32 constant TRANSFER_AND_CALL_DELEGATED_DATA_TYPEHASH = keccak256(
+        "TransferAndCallDelegatedData(address contractAddr,string method,address to,uint256 value,bytes data,uint256 maxReward,uint256 nonce)"
+    );
+
+    bytes32 constant TRANSFER_MULTIPLE_DELEGATED_DATA_TYPEHASH = keccak256(
+        "TransferMultipleDelegatedData(address contractAddr,string method,address[] addrs,uint256[] values,uint256 maxReward,uint256 nonce)"
+    );
+
+    bytes32 DOMAIN_SEPARATOR;
+
+    constructor () public {
+        DOMAIN_SEPARATOR = hash(EIP712Domain({
+            name: "LikeCoin",
+            version: '1',
+            chainId: 1,
+            verifyingContract: 0x02F61Fd266DA6E8B102D4121f5CE7b992640CF98
+        }));
+    }
+
+    function hash(EIP712Domain eip712Domain) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            EIP712DOMAIN_TYPEHASH,
+            keccak256(bytes(eip712Domain.name)),
+            keccak256(bytes(eip712Domain.version)),
+            eip712Domain.chainId,
+            eip712Domain.verifyingContract
+        ));
+    }
+
+    function hash(TransferDelegatedData data) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            TRANSFER_DELEGATED_DATA_TYPEHASH,
+            data.contractAddr,
+            keccak256(bytes(data.method)),
+            data.to,
+            data.value,
+            data.maxReward,
+            data.nonce
+        ));
+    }
+
+    function hash(TransferAndCallDelegatedData data) internal pure returns (bytes32) {
+        return keccak256(abi.encode(
+            TRANSFER_AND_CALL_DELEGATED_DATA_TYPEHASH,
+            data.contractAddr,
+            keccak256(bytes(data.method)),
+            data.to,
+            data.value,
+            keccak256(data.data),
+            data.maxReward,
+            data.nonce
+        ));
+    }
+
+    function hash(TransferMultipleDelegatedData data) internal pure returns (bytes32) {
+        bytes32 addrsHash = keccak256(abi.encodePacked(data.addrs));
+        bytes32 valuesHash = keccak256(abi.encodePacked(data.values));
+        return keccak256(abi.encode(
+            TRANSFER_MULTIPLE_DELEGATED_DATA_TYPEHASH,
+            data.contractAddr,
+            keccak256(bytes(data.method)),
+            addrsHash,
+            valuesHash,
+            data.maxReward,
+            data.nonce
+        ));
+    }
+
     function _bytesToSignature(bytes sig) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
         require(sig.length == 65);
         assembly {
@@ -27,17 +139,11 @@ contract SignatureCheckerImpl {
             s := mload(add(sig, 64))
             v := and(mload(add(sig, 65)), 0xFF)
         }
+        if (v < 27) {
+            v += 27;
+        }
         return (v, r, s);
     }
-
-    bytes32 transferDelegatedHash = keccak256(
-        "address contract",
-        "string method",
-        "address to",
-        "uint256 value",
-        "uint256 maxReward",
-        "uint256 nonce"
-    );
 
     function checkTransferDelegated(
         address _from,
@@ -47,23 +153,21 @@ contract SignatureCheckerImpl {
         uint256 _nonce,
         bytes _signature
     ) public constant returns (bool) {
-        bytes32 hash = keccak256(
-            transferDelegatedHash,
-            keccak256(msg.sender, "transferDelegated", _to, _value, _maxReward, _nonce)
-        );
+        bytes32 digest = keccak256(abi.encodePacked(
+            "\x19\x01",
+            DOMAIN_SEPARATOR,
+            hash(TransferDelegatedData({
+                contractAddr: msg.sender,
+                method: "transferDelegated",
+                to: _to,
+                value: _value,
+                maxReward: _maxReward,
+                nonce: _nonce
+            }))
+        ));
         var (v, r, s) = _bytesToSignature(_signature);
-        return ecrecover(hash, v, r, s) == _from;
+        return 0x0 != _from && ecrecover(digest, v, r, s) == _from;
     }
-
-    bytes32 transferAndCallDelegatedHash = keccak256(
-        "address contract",
-        "string method",
-        "address to",
-        "uint256 value",
-        "bytes data",
-        "uint256 maxReward",
-        "uint256 nonce"
-    );
 
     function checkTransferAndCallDelegated(
         address _from,
@@ -74,22 +178,22 @@ contract SignatureCheckerImpl {
         uint256 _nonce,
         bytes _signature
     ) public constant returns (bool) {
-        bytes32 hash = keccak256(
-            transferAndCallDelegatedHash,
-            keccak256(msg.sender, "transferAndCallDelegated", _to, _value, _data, _maxReward, _nonce)
-        );
+        bytes32 digest = keccak256(abi.encodePacked(
+            "\x19\x01",
+            DOMAIN_SEPARATOR,
+            hash(TransferAndCallDelegatedData({
+                contractAddr: msg.sender,
+                method: "transferAndCallDelegated",
+                to: _to,
+                value: _value,
+                data: _data,
+                maxReward: _maxReward,
+                nonce: _nonce
+            }))
+        ));
         var (v, r, s) = _bytesToSignature(_signature);
-        return ecrecover(hash, v, r, s) == _from;
+        return 0x0 != _from && ecrecover(digest, v, r, s) == _from;
     }
-
-    bytes32 transferMultipleDelegatedHash = keccak256(
-        "address contract",
-        "string method",
-        "address[] addrs",
-        "uint256[] values",
-        "uint256 maxReward",
-        "uint256 nonce"
-    );
 
     function checkTransferMultipleDelegated(
         address _from,
@@ -99,11 +203,19 @@ contract SignatureCheckerImpl {
         uint256 _nonce,
         bytes _signature
     ) public constant returns (bool) {
-        bytes32 hash = keccak256(
-            transferMultipleDelegatedHash,
-            keccak256(msg.sender, "transferMultipleDelegated", _addrs, _values, _maxReward, _nonce)
-        );
+        bytes32 digest = keccak256(abi.encodePacked(
+            "\x19\x01",
+            DOMAIN_SEPARATOR,
+            hash(TransferMultipleDelegatedData({
+                contractAddr: msg.sender,
+                method: "transferMultipleDelegated",
+                addrs: _addrs,
+                values: _values,
+                maxReward: _maxReward,
+                nonce: _nonce
+            }))
+        ));
         var (v, r, s) = _bytesToSignature(_signature);
-        return ecrecover(hash, v, r, s) == _from;
+        return 0x0 != _from && ecrecover(digest, v, r, s) == _from;
     }
 }

--- a/likechain-contracts/LikeChainHTLC.sol
+++ b/likechain-contracts/LikeChainHTLC.sol
@@ -1,0 +1,81 @@
+//    Copyright (C) 2018 LikeCoin Foundation Limited
+//
+//    This file is part of LikeCoin Smart Contract.
+//
+//    LikeCoin Smart Contract is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    LikeCoin Smart Contract is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with LikeCoin Smart Contract.  If not, see <http://www.gnu.org/licenses/>.
+
+
+pragma solidity ^0.4.25;
+
+import "github.com/OpenZeppelin/openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import "./TransferAndCallReceiver.sol";
+
+contract LikeCoinHTLC is TransferAndCallReceiver {
+    IERC20 public like;
+    
+    struct TransferInfo {
+        uint8 state; // 0: unset, 1: initiated, 2: executed, 3: revoked
+        address from;
+        address to;
+        uint256 value;
+        uint expiry;
+        bytes32 hashlock;
+    }
+    
+    mapping(bytes32 => TransferInfo) public transferInfo;
+    
+    event TransferInitiated(bytes32 _id, address indexed _to, address indexed _from, uint256 _value, uint _expiry, bytes32 _hashlock);
+    event TransferExecuted(bytes32 indexed _id, bytes32 _secret);
+    event TransferRevoked(bytes32 indexed _id);
+    
+    constructor(address _like) public {
+        like = IERC20(_like);
+    }
+    
+    function tokenCallback(address _from, uint256 _value, bytes _data) public {
+        // require(msg.sender == address(like));
+        address to;
+        uint expiry; 
+        bytes32 hashlock;
+        assembly {
+            to := and(mload(add(_data, 20)), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+            expiry := mload(add(_data, 52))
+            hashlock := mload(add(_data, 84))
+        }
+        require(expiry > now + 1800);
+        bytes32 id = keccak256(abi.encodePacked(_from, to, _value, _data, now));
+        require(transferInfo[id].state == 0);
+        transferInfo[id] = TransferInfo({ from: _from, to: to, value: _value, expiry: expiry, hashlock: hashlock, state: 1 });
+        emit TransferInitiated(id, to, _from, _value, expiry, hashlock);
+    }
+    
+    function executeTransfer(bytes32 _id, bytes32 _secret) public {
+        TransferInfo storage info = transferInfo[_id];
+        require(info.state == 1);
+        require(now < info.expiry);
+        require(sha256(abi.encodePacked(_secret)) == info.hashlock);
+        info.state = 2;
+        like.transfer(info.to, info.value);
+        emit TransferExecuted(_id, _secret);
+    }
+    
+    function revokeTransfer(bytes32 _id) public {
+        TransferInfo storage info = transferInfo[_id];
+        require(info.state == 1);
+        require(now >= info.expiry);
+        info.state = 3;
+        like.transfer(info.from, info.value);
+        emit TransferRevoked(_id);
+    }
+}

--- a/likechain-contracts/LikeChainRelayInterface.sol
+++ b/likechain-contracts/LikeChainRelayInterface.sol
@@ -1,0 +1,52 @@
+//    Copyright (C) 2018 LikeCoin Foundation Limited
+//
+//    This file is part of LikeCoin Smart Contract.
+//
+//    LikeCoin Smart Contract is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    LikeCoin Smart Contract is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with LikeCoin Smart Contract.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.4.25;
+
+import "github.com/OpenZeppelin/openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+
+contract LikeChainRelayLogicInterface {
+    function commitWithdrawHash(uint64 height, uint64 round, bytes _payload) public;
+    function updateValidator(address[] _newValidators, bytes _proof) public;
+    function withdraw(bytes _withdrawInfo, bytes _proof) public;
+    function upgradeLogicContract(address _newLogicContract, bytes _proof) public;
+    event Upgraded(uint256 _newLogicContractIndex, address _newLogicContract);
+}
+
+contract LikeChainRelayState {
+    uint256 public logicContractIndex;
+    address public logicContract;
+
+    IERC20 public tokenContract;
+
+    address[] public validators;
+    
+    struct ValidatorInfo {
+        uint8 index;
+        uint32 power;
+    }
+    
+    mapping(address => ValidatorInfo) public validatorInfo;
+    uint256 public totalVotingPower;
+    uint public lastValidatorUpdateTime;
+
+    uint public latestBlockHeight;
+    bytes32 public latestWithdrawHash;
+
+    mapping(bytes32 => bool) public consumedIds;
+    mapping(bytes32 => bytes32) public reserved;
+}

--- a/likechain-contracts/LikeChainRelayLogic.sol
+++ b/likechain-contracts/LikeChainRelayLogic.sol
@@ -1,0 +1,702 @@
+//    Copyright (C) 2018 LikeCoin Foundation Limited
+//
+//    This file is part of LikeCoin Smart Contract.
+//
+//    LikeCoin Smart Contract is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    LikeCoin Smart Contract is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with LikeCoin Smart Contract.  If not, see <http://www.gnu.org/licenses/>.
+
+// Introduction
+// 
+// This smart contract (the Relay contract) acts as the gateway between LikeChain and Ethereum.
+// When LikeCoin is transferred into this smart contract, the Transfer event will be received by the
+// background services of LikeChain, which will then fire corresponding Deposit transaction onto
+// LikeChain through Tendermint, minting LikeCoin on LikeChain.
+// When someone withdraw on LikeChain, it will create a record in the Merkle tree in LikeChain.
+// The Merkle root of the tree will be committed onto this smart contract periodically. Then, the user
+// (or operators of LikeChain, or other third-parties) can commit the Merkle proof to prove that there
+// exists such a withdraw record, releasing the LikeCoin previously transferred and locked in this contract.
+//
+// The main flow is as follows:
+// 1. Someone calls commitWithdrawHash with a payload containing votes, app hash, Merkle proof, etc.
+// 2. The contract checks if the votes from the validators are valid.
+// 3. The contract extracts block hash from the votes.
+// 4. The contract checks if the app hash is in the block hash by validating the Merkle proof.
+// 5. If everything are fine, the contract extracts the withdraw hash from app hash.
+// 6. When someone calls withdraw, the contract checks the Merkle proof from the call data to see if
+//    the withdraw data is actually in the Merkle tree of the withdraw hash committed previously.
+// 7. After checking, the contract transfers LikeCoin according to the withdraw info.
+// 
+//
+// Tendermint sign bytes format:
+// Tendermint runs using BFT algorithms. Every block produced is signed by >2/3 of validators before
+// being a valid block.
+// The signatures are signed on the SHA-256 hash of the "sign bytes" of the vote. Therefore the contract
+// needs to reconstruct the sign bytes before validating the signatures.
+// The sign bytes in the votes starting from Tendermint v0.26 is changed to amino encoding.
+// The structure and field-order is as follows:
+//
+// type CanonicalVote struct {
+//     Type      SignedMsgType // type alias for byte
+//     Height    int64         `binary:"fixed64"`
+//     Round     int64         `binary:"fixed64"`
+//     Timestamp time.Time
+//     BlockID   CanonicalBlockID
+//     ChainID   string
+// }
+// 
+// type CanonicalBlockID struct {
+//     Hash        cmn.HexBytes
+//     PartsHeader CanonicalPartSetHeader
+// }
+// 
+// type CanonicalPartSetHeader struct {
+//     Hash  cmn.HexBytes
+//     Total int
+// }
+//
+// (cmn.HexBytes is defined as []byte)
+//
+// Type is encoded into one single byte.
+// Height and Round are encoded as 64-bit fixed-length integers, in little endian.
+// Timestamp is specially handled as a struct roughly as follows:
+//
+// type Time struct {
+//     Second int64 // Varint
+//     Nanosecond int32 // Varint, ranged from 0 to 999,999,999
+// }
+//
+// Varint encoding: (see https://developers.google.com/protocol-buffers/docs/encoding#varints)
+// 
+// Varint is used a lot in amino, so we will first explain the encoding of varint.
+// In a varint, only the last 7 bits of a byte is used as the encoding of the integer.
+// The first bit indicates whether the varint still has succeeding bytes.
+// For example: 10111011 11011000 10111101 00101011
+// The first byte is 10111011. The value part is 0111011. Since the first bit is 1, we still need other bytes.
+// The second byte is 11011000. The value part is 1011000. Since the first bit is 1, we still need other bytes.
+// The third byte is 10111101. The value part is 0111101. Since the first bit is 1, we still need other bytes.
+// The fourth byte is 00101011. The value part is 0101011. Since the first bit is 0, this is the end of this varint.
+// So the value of the varint will be 0111011 1011000 0111101 0101011 reversed and concatenated, which is 91188283 in decimals.
+// 
+// 
+// In amino, structs are serialized into binary in a way similar to Protobuf.
+// Basically, it is a key-value structure, where the key is the index of the field in the struct (starting from 1),
+// encoeded as varint.
+// For example, in CanonicalVote, Type has field index 1, Height has 2, etc. So the encoding could be decoded as a mapping:
+// {
+//     Field 1 => Type 2,
+//     Field 2 => Height 1337,
+//     Field 3 => Round 2345,
+//     Field 4 => {
+//         Field 1 => 1234 Seconds,
+//         Field 2 => 5678 Nanoseconds
+//     },
+//     ...
+// }
+//
+// If a field has default value (e.g. 0 in numbers), amino will not encode that field by default.
+// Amino encodes the fields in sequential order.
+//
+// Typ3: (see https://developers.google.com/protocol-buffers/docs/encoding#structure)
+// In addition to field index, 3 bits (called Typ3) are used in the key to indicate the length of the value:
+//
+// 0 - the field itself is a varint
+// 1 - fixed 8-byte length
+// 2 - Length prefixed (using varint)
+// 5 - fixed 4-byte length (not used in CanonicalVote)
+//
+// For example, the Type field has field index 1, and it is encoded as varint.
+// Therefore the key will be 00001|000 (Field 1, Typ3 0) = 0x08.
+// The Height field has field index 2, and it is encoded as 8 byte fixed length integer.
+// Therefore the key will be 00010|001 (Field 2, Typ3 1) = 0x11.
+// The Timestamp field has field index 4, and it is variable length.
+// Therefore the key will be 00100|010 (Field 4, Typ3 2) = 0x22.
+// Timestamp will be encoded in a length-prefixed format. Therefore if the length of the encoded value of
+// the timestamp is 14, then 14 will appear right after 0x22.
+//
+// Below is an example of sign bytes:
+// 
+// 0x760802110200000000000000220C08E881CADF0510E8A9E088032A480A2042288B2C20A42426A9E80F2B6D7BAA7DCEC8F7DC5B63FF5360CE8B9B7C78B5DE12240A2052F24411779931CCF793D9C222B48EFB63C034CCACBB336B655FCB3F331EBCF310013211746573742D636861696E2D77467A62616B
+// 
+// which is disassembled below:
+//
+// 76 # length of the sign bytes (in varint, not including the length field itself), which is 0x76 = 118 bytes
+//     08 # 00001000 = 00001|000 = Field 1 (Type), Typ3 0 (varint)
+//         02 # value of Type field = 2
+//     11 # 00010001 = 00010|001 = Field 2 (Height), Typ3 1 (8 bytes)
+//         0200000000000000 # value of Height field (in int64, little endian) = 2
+//     22 # 00100010 = 00100|010 = Field 4 (Timestamp), Typ3 2 (length prefixed) (note that Field 3 (Round) is missing, hence the value is default value, which is 0)
+//         0C # length of the Timestamp field = 0x0C = 12
+//             08 # 00001000 = 00001|000 = Field 1 (Timestamp.Second), Typ3 0 (varint)
+//                 E881CADF05 # value of the Timestamp.Second field = 11101000 10000001 11001010 11011111 00000101, actual value = 0000101 1011111 1001010 0000001 1101000 = 1542619368
+//             10 # 00010000 = 00010|000 = Field 2 (Timestamp.Nanosecond), Typ3 0 (varint)
+//                 E8A9E08803 # value of the Timestamp.Nanosecond field = 11101000 10101001 11100000 10001000 00000011, actual value = 0000011 0001000 1100000 0101001 1101000 = 823661800
+//     2A # 00101010 = 00101|010 = Field 5 (BlockID), Typ3 2 (length prefixed)
+//         48 # length of the BlockID field = 0x48 = 72
+//             0A # 00001010 = 00001|010 = Field 1 (BlockID.Hash), Typ3 2 (length prefixed)
+//                 20 # length of the BlockID.Hash field = 0x20 = 32
+//                     42288B2C20A42426A9E80F2B6D7BAA7DCEC8F7DC5B63FF5360CE8B9B7C78B5DE # Value of the BlockID.Hash field
+//             12 # 00010010 = 00010|010 = Field 2 (BlockID.PartsHeader), Typ3 2 (length prefixed)
+//                 24 # length of the BlockID.Hash field = 0x24 = 36
+//                     0A # 00001010 = 00001|010 = Field 1 (BlockID.PartsHeader.Hash), Typ3 2 (length prefixed)
+//                         20 # length of the BlockID.PartsHeader.Hash field = 0x20 = 32
+//                             52F24411779931CCF793D9C222B48EFB63C034CCACBB336B655FCB3F331EBCF3 # Value of the BlockID.PartsHeader.Hash field
+//                     10 # 00010000 = 00010|000 = Field 2 (BlockID.PartsHeader.Total), Typ3 0 (varint)
+//                         01 # value of BlockID.PartsHeader.Total field = 1
+//     32 # 00110010 = 00110|010 = Field 6 (ChainID), Typ3 2 (length prefixed)
+//         11 # length of the ChainID field = 0x11 = 17
+//             746573742D636861696E2D77467A62616B # value of the ChainID field = "test-chain-wFzbak"
+//
+// A few points to note:
+// 1. Every field except the Timestamp field in the sign bytes should be the same among all the votes of the validators on the same block number
+// 2. Timestamp has varint, therefore could affect the length of the sign bytes, and also the offsets of the fields afterwards
+// 3. After confirming the offset of the BlockID part, the offset of t he block hash could also be confirmed, since every hash has fixed length 32
+//
+// Application hash:
+// In Tendermint, the application logic is defined by developer. The state of the application is reported
+// to Tendermint by application hash (app hash).
+// LikeChain defines the app hash as the concatenation of 2 hashes: withdraw hash and state hash.
+// Withdraw hash is the Merkle root of a tree containing info which the Relay contract should know.
+// State hash is the Merkle root of the tree containing the remaining states.
+// The reason of splitting them into 2 trees is to reduce the length of Merkle proof when doing withdraw.
+// 
+// The app hash will be in the block header of a block. The fields in the block header will be aggregated
+// into a simple Merkle tree, which the tree root will be the block hash. Therefore we can use a Merkle proof
+// to prove that the app hash is really inside the header with specific block hash.
+//
+// Details could be found at https://github.com/tendermint/tendermint/blob/master/types/block.go#L388
+//
+//
+// Payload encoding to the contract:
+// The encoding of the votes onto the contract is as follows:
+// 1. the Height and Round are passed onto the contract by function parameters directly
+// 2. the remaining parts are encoded into a big bytes
+// 3. by the Height and Round, we can construct the parts before Timestamp (Type is fixed as 2)
+// 4. for every validators in this block, Timestamp and the signature is encoded
+// 5. the remaining parts after Timestamp (called "suffix") is encoded
+// 6. the Merkle proof for proving the app hash in the block hash is encoded
+//
+// The structure is like this:
+//
+// type AppHashContractProof struct {
+// 	Height     uint64
+// 	Round      uint64
+// 	Payload struct {
+// 		SuffixLen  uint8
+// 		Suffix     []byte
+// 		VotesCount uint8
+// 		Votes      []struct {
+// 			TimeLen uint8
+// 			Time    []byte
+// 			Sig     [65]byte
+// 		}
+// 		AppHashLen   uint8
+// 		AppHash      []byte
+// 		AppHashProof [4][32]byte
+// 	}
+// }
+//
+// We assume that the total length of the sign bytes are <= 127, so uint8 could be used as varint prefix.
+// The length restriction could be calculated as follows:
+//
+// Type: 1 byte field number + 1 byte value = 2 bytes
+// Height: 1 byte field numnber + 8 bytes value = 9 bytes
+// Round: 1 byte field numnber + 8 bytes value = 9 bytes
+// Timestamp: 1 byte field numnber + 1 byte length +
+//           1 byte field number + 6 bytes varint second (at most 43 bits, enough for ~278,731 years since 1970) +
+//           1 byte field number + 5 bytes varint nanosecond (at most 36 bits, enough since maximum value is 999,999,999, which is < 2^36)
+// = 15 bytes
+// BlockID: 1 byte field numnber + 1 byte length +
+//              1 byte field number + 1 byte length + 32 bytes value +
+//              1 byte field number + 1 bytes length +
+//                  1 byte field number + 1 byte length + 32 byte value +
+//                  1 byte field number + 1 byte value
+// = 74 bytes
+// ChainID: 1 byte field numnber + 1 byte length + n bytes value = (n + 2) bytes
+// Total = 111 + n bytes
+// 
+// So we have 111 + n <= 127, which means ChainID should have length <= 16.
+// In practice, Timestamp is shorter than the maximum (until ~year 4140), and Round usually have default value 0,
+// therefore the restriction is not that strict, but should still be considered.
+//
+//
+//  
+// IAVL RangeProof:
+// In IAVL tree, RangeProof is used to prove that a range of values ("sibling" leaves) are inside the tree.
+// It is also possible to prove that a value is absent in the tree, by proving a range is in the tree and the
+// value should appear in that range if it is present.
+// In this contract, we are only using RangeProof with only one leaf.
+//
+// The definition of RangeProof struct is as follows:
+// (See https://github.com/tendermint/iavl/blob/master/proof_range.go#L216 for source code)
+//
+// type RangeProof struct {
+// 	// You don't need the right path because
+// 	// it can be derived from what we have.
+// 	LeftPath   PathToLeaf      `json:"left_path"`
+// 	InnerNodes []PathToLeaf    `json:"inner_nodes"`
+// 	Leaves     []proofLeafNode `json:"leaves"`
+//
+// 	// memoize
+// 	rootVerified bool
+// 	rootHash     []byte // valid iff rootVerified is true
+// 	treeEnd      bool   // valid iff rootVerified is true
+//
+// }
+//
+// type PathToLeaf []proofInnerNode
+//
+// type proofInnerNode struct {
+// 	Height  int8   `json:"height"`
+// 	Size    int64  `json:"size"`
+// 	Version int64  `json:"version"`
+// 	Left    []byte `json:"left"`
+// 	Right   []byte `json:"right"`
+// }
+//
+// type proofLeafNode struct {
+// 	Key       cmn.HexBytes `json:"key"`
+// 	ValueHash cmn.HexBytes `json:"value"`
+// 	Version   int64        `json:"version"`
+// }
+//
+// In case of there is only one leaf in the RangeProof, InnerNodes will be empty and Leaves will only contain one node.
+// In this case, the procedure of computing root hash is as follows:
+// 
+// 1. Encode leaf node in binary.
+//   1.1. Encode Height (0) as int8 (one single byte).
+//   1.2. Encode Size (1) as varint.
+//        (note that it is an integer, which could be negative, and is encoded in zigzag encoding in varint, so positive
+//        number n will be encoded as 2n, i.e. 0x02 is used for encoding 1)
+//   1.3. Encode Version as varint.
+//   1.4. Encode Key by prefixing length in varint, then encode the bytes.
+//   1.5. Encode ValueHash by prefixing length in varint, then encode the bytes.
+// 2. Hash the encoded binary by SHA-256 to get current hash.
+// 3. Repeatedly mix inner nodes (from bottom to up) into current hash to update current hash, until reaching the top.
+//   3.1. Encode Height as int8 (one single byte).
+//   3.2. Encode Size as varint.
+//   3.3. Encode Version as varint.
+//   3.4. Encode current hash and one of Left or Right. (One of Left or Right must be empty)
+//     3.4.1. If Left is empty, then first encode current hash (prefix length), then encode Right (prefix length).
+//     3.4.2. If Right is empty, then first encode Left (prefix length), then encode current hash (prefix length).
+//
+// Payload encoding to the contract:
+// The proof has 2 parts: leaf and inner nodes.
+// For leaf, only the version is needed. However, since it is varint, we also need to know the length of the version field.
+// For inner nodes, we need to know all the info, plus whether current hash should be Left or Right, to decide the hashing order.
+// There we need to encode the followings:
+//
+// 1. Length of leaf Version
+// 2. Leaf version
+// 3. Number of inner nodes
+// 4. Inner nodes
+//   4.1. Length of all the parts except Left or Right. This part is called "prefix".
+//   4.2. One bit for indicating whether current hash should be Left or Right.
+//   4.3. The prefix
+//   4.4. The Left or Right in the inner node. This is called "sibling".
+//
+// Further investigation shows that the prefix part of inner nodes will never exceed 127 bytes.
+// Therefore the "one bit" is encoded together with the prefix length.
+// The final format is as follows:
+//
+// type ContractIAVLTreeProof struct {
+// 	VersionLength    uint8
+// 	LeafVersionBytes []byte
+// 	PathLength       uint8
+// 	Path             []struct {
+// 		PrefixLengthAndOrder uint8 // first bit indicates the node is left or right
+// 		Prefix               []byte
+// 		Sibling              []byte
+// 	}
+// }
+
+
+
+
+
+
+pragma solidity ^0.4.25;
+
+import "./LikeChainRelayInterface.sol";
+
+contract LikeChainRelayLogic is LikeChainRelayState, LikeChainRelayLogicInterface {
+    constructor(address[] _validators, uint32[] _votingPowers, address _tokenContract) public {
+        uint len = _validators.length;
+        require(len > 0);
+        require(len < 256);
+        require(_votingPowers.length == len);
+
+        for (uint8 i = 0; i < len; i += 1) {
+            address v = _validators[i];
+            require(validatorInfo[v].power == 0);
+            uint32 power = _votingPowers[i];
+            require(power > 0);
+            validators.push(v);
+            validatorInfo[v] = ValidatorInfo({
+                index: i,
+                power: power
+            });
+            totalVotingPower += power;
+        }
+        
+        tokenContract = IERC20(_tokenContract);
+    }
+    
+    function _proofRootHash(bytes32 _key, bytes32 _value, bytes _proof) internal view returns (bytes32 rootHash) {
+        assembly {
+            let start := mload(0x40)
+            let p := start
+            let curHashStart := add(start, 128)
+            let data := add(_proof, 33) // 32 byte length + 1 byte reserved
+            
+            let len := and(mload(sub(data, 31)), 0xff) // version length
+            if gt(len, 9) { revert(0, 0) } // version is uint64, so the varint encoded should never longer than 9 bytes
+            data := add(data, 1)
+            mstore(p, hex"0002")
+            p := add(p, 2)
+            mstore(p, mload(data))
+            data := add(data, len)
+            p := add(p, len)
+            mstore8(p, 32) // amino length-prefixed encoding for []byte (length 32)
+            p := add(p, 1)
+            mstore(p, _key)
+            p := add(p, 32)
+            mstore8(p, 32) // amino length-prefixed encoding for []byte (length 32)
+            p := add(p, 1)
+            mstore(p, _value)
+            p := add(p, 32)
+            let _ := staticcall(gas, 2, start, sub(p, start), curHashStart, 32)
+            
+            len := and(mload(sub(data, 31)), 0xff) // number of path nodes
+            data := add(data, 1)
+            for { let i := len } gt(i, 0) { i := sub(i, 1) } {
+                p := start
+                len := and(mload(sub(data, 31)), 0xff) // 1 bit left-right indicator, 7 bits length
+                let order := and(len, 0x80)
+                len := and(len, 0x7f)
+                if gt(len, 19) { revert(0, 0) } // 1-byte height (< 128) + 9-byte 64-bit varint-encoded numbers * 2
+                data := add(data, 1)
+                mstore(p, mload(data))
+                p := add(p, len)
+                data := add(data, len)
+                switch order
+                case 0 {
+                    mstore8(p, 32) // amino length-prefixed encoding for []byte
+                    p := add(p, 1)
+                    mstore(p, mload(curHashStart))
+                    p := add(p, 32)
+                    mstore8(p, 32) // amino length-prefixed encoding for []byte
+                    p := add(p, 1)
+                    mstore(p, mload(data))
+                    p := add(p, 32)
+                } default {
+                    mstore8(p, 32) // amino length-prefixed encoding for []byte
+                    p := add(p, 1)
+                    mstore(p, mload(data))
+                    p := add(p, 32)
+                    mstore8(p, 32) // amino length-prefixed encoding for []byte
+                    p := add(p, 1)
+                    mstore(p, mload(curHashStart))
+                    p := add(p, 32)
+                }
+                data := add(data, 32)
+                _ := staticcall(gas, 2, start, sub(p, start), curHashStart, 32)
+            }
+            len := mload(_proof)
+            if gt(sub(data, add(_proof, 32)), len) {
+                revert(0, 0)
+            }
+            rootHash := mload(curHashStart)
+        }
+        return rootHash;
+    }
+    
+    // See https://tendermint.com/docs/spec/blockchain/blockchain.html#lastcommit
+    function commitWithdrawHash(uint64 height, uint64 round, bytes _payload) public {
+        // Memory layout:
+        // 0..127: sign bytes
+        // 128..: temporary storage e.g. computing mapping storage position by hash, recovering address
+        assembly {
+            // The n bytes are at the beginning of a 32-byte word, with zeros following
+            function getNByte(p, n) -> bs {
+                if gt(n, 32) {
+                    revert(0, 0)
+                }
+                let numberOfOnes := mul(n, 8)
+                let numberOfZeros := sub(256, numberOfOnes)
+                // mask == 111111...11100000...000, with (8*n) 1s and (256 - 8*n) 0s
+                let mask := 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                mask := xor(mask, sub(exp(2, numberOfZeros), 1))
+                bs := and(mload(p), mask)
+            }
+            
+            // The byte is at the end of a 32-byte word
+            function getOneByte(p) -> b {
+                // b := and(mload(sub(p, 31)), 0xFF)
+                b := byte(0, mload(p))
+            }
+            
+            // Takes the height and round, reconstruct the prefix part of the amino-encoded sign bytes,
+            // which contains type (0x02), height, round
+            function reconstructPrefix(p, height, round) -> next {
+                mstore8(p, 0x00) // place-holder for length prefix
+                p := add(p, 1)
+                mstore8(p, 0x08) // field number for `type`
+                p := add(p, 1)
+                mstore8(p, 0x02) // value for `precommit` type
+                p := add(p, 1)
+                if gt(height, 0) {
+                    mstore8(p, 0x11) // field number for `height`
+                    p := add(p, 1)
+                    for { let i := 0 } lt(i, 8) { i := add(i, 1) } {
+                        mstore8(p, mod(height, 0x100))
+                        height := div(height, 0x100)
+                        p := add(p, 1)
+                    }
+                }
+                if gt(round, 0) {
+                    mstore8(p, 0x19) // field number for `round`
+                    p := add(p, 1)
+                    for { let i := 0 } lt(i, 8) { i := add(i, 1) } {
+                        mstore8(p, mod(round, 0x100))
+                        height := div(round, 0x100)
+                        p := add(p, 1)
+                    }
+                }
+                next := p
+            }
+            
+            function extractBlockHash(suffix) -> blockHash {
+                blockHash := mload(add(suffix, 4))
+            }
+            
+            // Note that copy is done in words, so the last word may overwrite some bytes
+            function memcpy(dst, src, len) {
+                let dstEnd := add(dst, len)
+                for { } lt(dst, dstEnd) { dst := add(dst, 32) src := add(src, 32) } {
+                    mstore(dst, mload(src))
+                }
+            }
+            
+            // 1. copy `timeLength` bytes from `timeSource` to `timeStart`
+            // 2. copy `suffixLength` bytes from `suffixSource` to the location next to time
+            // 3. calculate the total length of the content and write to starting position
+            function reconstructSignBytes(p, timeStart, time, timeLen, suffixSrc, suffixLen) -> end {
+                let start := p
+                mstore(timeStart, time)
+                p := add(timeStart, timeLen)
+                memcpy(p, suffixSrc, suffixLen)
+                end := add(p, suffixLen)
+                let len := sub(end, add(start, 1))
+                mstore8(start, len)
+            }
+            
+            function getVoter(p, timeStart, suffixSrc, suffixLen) -> voter, next {
+                let msgStart := mload(0x40)
+                let timeLen := getOneByte(p)
+                if gt(timeLen, 15) { revert(0, 0) }
+                p := add(p, 1)
+                let time := getNByte(p, timeLen)
+                p := add(p, timeLen)
+                let msgEnd := reconstructSignBytes(msgStart, timeStart, time, timeLen, suffixSrc, suffixLen)
+                
+                // ecrecover precompiled contract
+                // Contract address: 1
+                // Input: bytes32 hash, uint v, bytes32 r, bytes32 s
+                // Output: address signer
+
+                let buf := add(msgStart, 128)
+                let _ := staticcall(gas, 2, msgStart, sub(msgEnd, msgStart), buf, 32) // SHA-256 hash, at buf[0:32]
+                mstore(add(buf, 32), getOneByte(p)) // v at buf[32:64]
+                p := add(p, 1)
+                mstore(add(buf, 64), mload(p)) // r at buf[64:96]
+                p := add(p, 32)
+                mstore(add(buf, 96), mload(p)) // s at buf[96:128]
+                p := add(p, 32)
+                let succ := staticcall(gas, 1, buf, 128, buf, 32)
+                if iszero(succ) {
+                    revert(0, 0)
+                }
+                voter := mload(buf)
+                next := p
+            }
+            
+            // For layout of mapping, see
+            // https://solidity.readthedocs.io/en/v0.4.24/miscellaneous.html#layout-of-state-variables-in-storage
+            function getVoterInfo(addr) -> index, power {
+                let buf := add(mload(0x40), 128)
+                mstore(buf, addr)
+                mstore(add(buf, 32), validatorInfo_slot)
+                let slot := keccak256(buf, 64)
+                let votingInfo := sload(slot)
+                if eq(votingInfo, 0) {
+                    revert(0, 0)
+                }
+                index := and(votingInfo, 0xFF)
+                power := and(div(votingInfo, 0x100), 0xFFFFFFFF)
+            }
+            
+            function accumulateVoterPower(voter, votedSet, power) -> newVotedSet, newPower {
+                let voterIndex, voterPower := getVoterInfo(voter)
+                let mask := exp(2, voterIndex)
+                if iszero(eq(0, and(votedSet, mask))) {
+                    revert(0, 0)
+                }
+                newVotedSet := or(votedSet, mask)
+                newPower := add(power, voterPower)
+            }
+            
+            function checkVotes(p, height, round) -> blockHash, next {
+                let votedSet := 0
+                let voterPower := 0
+                
+                let suffixLen := getOneByte(p)
+                if gt(suffixLen, 92) { revert(0, 0) }
+                p := add(p, 1)
+                let suffixSrc := p
+                p := add(p, suffixLen)
+                blockHash := extractBlockHash(suffixSrc)
+                
+                let msgStart := mload(0x40)
+                let timeStart := reconstructPrefix(msgStart, height, round)
+                
+                let votesCount := getOneByte(p)
+                p := add(p, 1)
+                for {} gt(votesCount, 0) { votesCount := sub(votesCount, 1) } {
+                    let voter
+                    voter, p := getVoter(p, timeStart, suffixSrc, suffixLen)
+                    votedSet, voterPower := accumulateVoterPower(voter, votedSet, voterPower)
+                }
+                // Need strictly more than 2/3 of total voting power
+                if iszero(gt(mul(voterPower, 3), mul(sload(totalVotingPower_slot), 2))) {
+                    revert(0, 0)
+                }
+                next := p
+            }
+            
+            // The blockHash is the Merkle root of 16 fields (including AppHash) in the block header.
+            // Therefore we can use a Merkle proof to prove the appHash is in the block header.
+            // The Merkle root is computed as follows:
+            // 1. Each field is amino-encoded into a []byte. For []byte, it is done by prefixing len(bs).
+            // 2. The resulting []byte will be hashed again to get a leaf node in the Merkle tree.
+            // 3. Each pair of leaf nodes are amino-encoded and concated, then hashed into the parent of these 2 nodes.
+            // 4. Repeat the process until reaching the root, which will be blockHash.
+            //
+            // So to verify the Merkle proof of the "App" field, the contract needs to:
+            // 1. hash "\x{appHashLen}{appHashLen-byte-appHash}" to get the leaf node for AppHash
+            // 2. Hash "\x20{leaf-node}\x20{proof-1}" to get new leaf node.
+            // 3. Hash "\x20{leaf-node}\x20{proof-2}" to get new leaf node.
+            // 4. Hash "\x20{proof-3}\x20{leaf-node}" to get new leaf node.
+            // 5. Hash "\x20{proof-4}\x20{leaf-node}" to get root hash.
+            // 6. Check if the root hash equals to blockHash
+            //
+            // Then the first 32 bytes of the AppHash will be extracted as the withdrawHash.
+            function extractAndProofWithdrawHash(p, blockHash) -> withdrawHash {
+                let buf := mload(0x40)
+                let aminoEncodedAppHashLen := add(getOneByte(p), 1)
+                // No need to `p := add(p, 1)`, as the amino-encoded appHash needs length prefix
+                memcpy(buf, p, aminoEncodedAppHashLen)
+                withdrawHash := mload(add(p, 1))
+                p := add(p, aminoEncodedAppHashLen)
+                
+                let left := add(buf, 1)
+                let right := add(buf, 34)
+                // 1. hash "\x{appHashLen}{appHashLen-byte-appHash}" to get the leaf node for AppHash
+                let _ := staticcall(gas, 2, buf, aminoEncodedAppHashLen, left, 32)
+                // 2. Hash "\x20{leaf-node}\x20{proof-1}" to get new leaf node.
+                mstore8(sub(left, 1), 32)
+                mstore8(sub(right, 1), 32)
+                mstore(right, mload(p))
+                p := add(p, 32)
+                _ := staticcall(gas, 2, buf, 66, left, 32)
+                // 3. Hash "\x20{leaf-node}\x20{proof-2}" to get new leaf node.
+                mstore(right, mload(p))
+                p := add(p, 32)
+                _ := staticcall(gas, 2, buf, 66, right, 32)
+                // 4. Hash "\x20{proof-3}\x20{leaf-node}" to get new leaf node.
+                mstore(left, mload(p))
+                p := add(p, 32)
+                _ := staticcall(gas, 2, buf, 66, right, 32)
+                // 5. Hash "\x20{proof-4}\x20{leaf-node}" to get root hash.
+                mstore(left, mload(p))
+                p := add(p, 32)
+                _ := staticcall(gas, 2, buf, 66, buf, 32)
+                // 6. Check if the root hash equals to blockHash
+                if iszero(eq(blockHash, mload(buf))) {
+                    revert(0, 0)
+                }
+            }
+            
+            if iszero(gt(height, sload(latestBlockHeight_slot))) {
+                revert(0, 0)
+            }
+            let blockHash
+            let p := add(_payload, 32)
+            blockHash, p := checkVotes(p, height, round)
+            let withdrawHash := extractAndProofWithdrawHash(p, blockHash)
+            sstore(latestBlockHeight_slot, height)
+            sstore(latestWithdrawHash_slot, withdrawHash)
+        }
+    }
+
+    // 1. reconstruct key from { from, to, value, fee, nonce }
+    // 2. pack [0, 1, leafVersionBytes, key, ONE_HASH]
+    // 3. hash packed output to get current hash
+    // 4. repeat the followings:
+    //    1. extract prefixBytes and suffixBytes
+    //    2. pack [prefixBytes, currentHash, suffixBytes]
+    //    3. hash packed output and update current hash
+    // 5. output current hash as root hash
+    
+    function _proofAndExtractWithdraw(bytes _withdrawInfo, bytes _proof) internal returns (address to, uint256 value, uint256 fee) {
+        bytes32 id = sha256(_withdrawInfo);
+        require(!consumedIds[id]);
+        consumedIds[id] = true;
+        bytes32 proofValueHash = hex"4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a"; // sha256 of hex"01", truncated
+        bytes32 rootHash = _proofRootHash(id, proofValueHash, _proof);
+        require(rootHash == latestWithdrawHash);
+        assembly {
+            to := mload(add(_withdrawInfo, 40))
+            value := mload(add(_withdrawInfo, 72))
+            fee := mload(add(_withdrawInfo, 104))
+        }
+        return (to, value, fee);
+    }
+
+    function withdraw(bytes _withdrawInfo, bytes _proof) public {
+        address to;
+        uint256 value;
+        uint256 fee;
+        (to, value, fee) = _proofAndExtractWithdraw(_withdrawInfo, _proof);
+        tokenContract.transfer(msg.sender, fee);
+        tokenContract.transfer(to, value);
+    }
+
+    function updateValidator(address[] _newValidators, bytes _proof) public {
+        // TODO
+    }
+    
+    // 1. reconstruct key by the format sha256("exec{big-endian encoded 64-bit contract index})"
+    // 2. get value hash by sha256(contract address)
+    // 3. prove that the key-value pair is in withdraw tree
+    // 4. update the contract and contract index
+    function upgradeLogicContract(address _newLogicContract, bytes _proof) public {
+        logicContractIndex += 1;
+        bytes12 keyBeforeHash = bytes12(uint96(bytes12("exec")) | uint96(logicContractIndex));
+        bytes32 key = sha256(abi.encodePacked(keyBeforeHash));
+        bytes32 proofValueHash = sha256(abi.encodePacked(_newLogicContract));
+        bytes32 rootHash = _proofRootHash(key, proofValueHash, _proof);
+        require(rootHash == latestWithdrawHash);
+        logicContract = _newLogicContract;
+        emit Upgraded(logicContractIndex, _newLogicContract);
+    }
+}

--- a/likechain-contracts/LikeChainRelayMain.sol
+++ b/likechain-contracts/LikeChainRelayMain.sol
@@ -1,0 +1,68 @@
+//    Copyright (C) 2018 LikeCoin Foundation Limited
+//
+//    This file is part of LikeCoin Smart Contract.
+//
+//    LikeCoin Smart Contract is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    LikeCoin Smart Contract is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with LikeCoin Smart Contract.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.4.25;
+
+import "./LikeChainRelayInterface.sol";
+
+contract LikeChainRelayMain is LikeChainRelayState, LikeChainRelayLogicInterface {
+    constructor(
+        address _logicContract,
+        address _tokenContract,
+        address[] _validators,
+        uint32[] _votingPowers
+    ) public {
+        uint len = _validators.length;
+        require(len > 0);
+        require(len < 256);
+        require(_votingPowers.length == len);
+        
+        logicContract = _logicContract;
+        logicContractIndex = 0;
+
+        for (uint8 i = 0; i < len; i += 1) {
+            address v = _validators[i];
+            require(validatorInfo[v].power == 0);
+            uint32 power = _votingPowers[i];
+            require(power > 0);
+            validators.push(v);
+            validatorInfo[v] = ValidatorInfo({
+                index: i,
+                power: power
+            });
+            totalVotingPower += power;
+        }
+        
+        tokenContract = IERC20(_tokenContract);
+    }
+
+    function commitWithdrawHash(uint64 /* height */, uint64 /* round */, bytes /* _payload */) public {
+        require(logicContract.delegatecall(msg.data));
+    }
+
+    function updateValidator(address[] /* _newValidators */, bytes /* _proof */) public {
+        require(logicContract.delegatecall(msg.data));
+    }
+
+    function withdraw(bytes /* _withdrawInfo */, bytes /* _proof */) public {
+        require(logicContract.delegatecall(msg.data));
+    }
+
+    function upgradeLogicContract(address /* _newLogicContract */, bytes /* _proof */) public {
+        require(logicContract.delegatecall(msg.data));
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -352,6 +352,19 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
     },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -1056,6 +1069,16 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
       "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
     },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1433,12 +1456,49 @@
         "xhr-request-promise": "^0.1.2"
       }
     },
+    "ethereumjs-abi": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
+      "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
+      "requires": {
+        "bn.js": "^4.10.0",
+        "ethereumjs-util": "^4.3.0"
+      },
+      "dependencies": {
+        "ethereumjs-util": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
+          "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
+          "requires": {
+            "bn.js": "^4.8.0",
+            "create-hash": "^1.1.2",
+            "keccakjs": "^0.2.0",
+            "rlp": "^2.0.0",
+            "secp256k1": "^3.0.1"
+          }
+        }
+      }
+    },
     "ethereumjs-testrpc": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-6.0.3.tgz",
       "integrity": "sha512-lAxxsxDKK69Wuwqym2K49VpXtBvLEsXr1sryNG4AkvL5DomMdeCBbu3D87UEevKenLHBiT8GTjARwN6Yj039gA==",
       "requires": {
         "webpack": "^3.0.0"
+      }
+    },
+    "ethereumjs-util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+      "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+      "requires": {
+        "bn.js": "^4.11.0",
+        "create-hash": "^1.1.2",
+        "ethjs-util": "^0.1.3",
+        "keccak": "^1.0.2",
+        "rlp": "^2.0.0",
+        "safe-buffer": "^5.1.1",
+        "secp256k1": "^3.0.1"
       }
     },
     "ethjs-abi": {
@@ -1477,6 +1537,15 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
+      }
+    },
+    "ethjs-util": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+      "requires": {
+        "is-hex-prefixed": "1.0.0",
+        "strip-hex-prefix": "1.0.0"
       }
     },
     "event-emitter": {
@@ -2981,6 +3050,17 @@
         "verror": "1.10.0"
       }
     },
+    "keccak": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+      "requires": {
+        "bindings": "^1.2.1",
+        "inherits": "^2.0.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "keccakjs": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
@@ -4117,6 +4197,14 @@
         "inherits": "^2.0.1"
       }
     },
+    "rlp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.1.0.tgz",
+      "integrity": "sha512-93U7IKH5j7nmXFVg19MeNBGzQW5uXW1pmCuKY8veeKIhYTE32C2d0mOegfiIAfXcHOKJjjPlJisn8iHDF5AezA==",
+      "requires": {
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -4158,6 +4246,21 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "secp256k1": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
+      "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+      "requires": {
+        "bindings": "^1.2.1",
+        "bip66": "^1.1.3",
+        "bn.js": "^4.11.3",
+        "create-hash": "^1.1.2",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.2.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
+      }
     },
     "semver": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
   "dependencies": {
     "bignumber.js": "^4.1.0",
     "eth-lib": "^0.2.5",
+    "ethereumjs-abi": "^0.6.5",
     "ethereumjs-testrpc": "^6.0.3",
+    "ethereumjs-util": "^5.2.0",
     "truffle": "^4.1.13",
     "web3-eth-abi": "^1.0.0-beta.35",
     "web3-utils": "^1.0.0-beta.35",

--- a/test/gas.js
+++ b/test/gas.js
@@ -21,7 +21,6 @@
 
 const utils = require('./utils.js');
 const web3Utils = require('web3-utils');
-const AccountLib = require('eth-lib/lib/account');
 const Accounts = require('./accounts.json');
 const web3Abi = require('web3-eth-abi');
 const ethUtil = require('ethereumjs-util');
@@ -44,16 +43,6 @@ const typedData = {
     verifyingContract: '0x02F61Fd266DA6E8B102D4121f5CE7b992640CF98',
   },
 };
-
-function signTypedCall(signData, privKey) {
-  const paramSignatures = signData.map(item => ({ type: 'string', value: `${item.type} ${item.name}` }));
-  const params = signData.map(item => ({ type: item.type, value: item.value }));
-  const hash = web3Utils.soliditySha3(
-    { type: 'bytes32', value: web3Utils.soliditySha3(...paramSignatures) },
-    { type: 'bytes32', value: web3Utils.soliditySha3(...params) },
-  );
-  return AccountLib.sign(hash, privKey);
-}
 
 function signTransferDelegated(likeAddr, to, value, maxReward, nonce, privKey) {
   const signData = {

--- a/test/gas.js
+++ b/test/gas.js
@@ -44,12 +44,10 @@ const typedData = {
   },
 };
 
-function signTransferDelegated(likeAddr, to, value, maxReward, nonce, privKey) {
+function signTransferDelegated(to, value, maxReward, nonce, privKey) {
   const signData = {
-    contractAddr: likeAddr,
-    method: 'transferDelegated',
     to,
-    value: `0x${value.toString(16)}`,
+    value: value.toFixed(),
     maxReward,
     nonce,
   };
@@ -57,12 +55,10 @@ function signTransferDelegated(likeAddr, to, value, maxReward, nonce, privKey) {
   return ethUtil.toRpcSig(sig.v, sig.r, sig.s);
 }
 
-function signTransferAndCallDelegated(likeAddr, to, value, data, maxReward, nonce, privKey) {
+function signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey) {
   const signData = {
-    contractAddr: likeAddr,
-    method: 'transferAndCallDelegated',
     to,
-    value: `0x${value.toString(16)}`,
+    value: value.toFixed(),
     data,
     maxReward,
     nonce,
@@ -71,12 +67,10 @@ function signTransferAndCallDelegated(likeAddr, to, value, data, maxReward, nonc
   return ethUtil.toRpcSig(sig.v, sig.r, sig.s);
 }
 
-function signTransferMultipleDelegated(likeAddr, addrs, values, maxReward, nonce, privKey) {
+function signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey) {
   const signData = {
-    contractAddr: likeAddr,
-    method: 'transferMultipleDelegated',
     addrs,
-    values: values.map(v => `0x${v.toString(16)}`),
+    values: values.map(v => v.toFixed()),
     maxReward,
     nonce,
   };
@@ -140,7 +134,7 @@ contract('LikeCoin Gas Estimation', (accounts) => {
     const claimedReward = 0;
     let nonce = web3Utils.randomHex(32);
     let signature =
-      signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+      signTransferDelegated(to, value, maxReward, nonce, privKey);
     let callResult = await like.transferDelegated(
       from, to, value, maxReward, claimedReward,
       nonce, signature, { from: accounts[2] },
@@ -148,7 +142,7 @@ contract('LikeCoin Gas Estimation', (accounts) => {
     console.log(`transferDelegated, first time gas used = ${callResult.receipt.gasUsed}`);
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+      signTransferDelegated(to, value, maxReward, nonce, privKey);
     callResult = await like.transferDelegated(
       from, to, value, maxReward, claimedReward,
       nonce, signature, { from: accounts[2] },
@@ -189,7 +183,7 @@ contract('LikeCoin Gas Estimation', (accounts) => {
     const claimedReward = 0;
     let nonce = web3Utils.randomHex(32);
     let signature =
-      signTransferMultipleDelegated(like.address, [accounts[0]], [0], maxReward, nonce, privKey);
+      signTransferMultipleDelegated([accounts[0]], [0], maxReward, nonce, privKey);
     await like.transferMultipleDelegated(
       from, [accounts[0]], [0], maxReward, claimedReward,
       nonce, signature, { from: accounts[1] },
@@ -199,7 +193,7 @@ contract('LikeCoin Gas Estimation', (accounts) => {
     let values = [1, 2, 3, 4, 5].map(n => coinsToCoinUnits(n * 100));
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     let callResult = await like.transferMultipleDelegated(
       from, addrs, values, maxReward, claimedReward,
       nonce, signature, { from: accounts[1] },
@@ -207,7 +201,7 @@ contract('LikeCoin Gas Estimation', (accounts) => {
     console.log(`transferMultipleDelegated, count = ${addrs.length}, first time gas used = ${callResult.receipt.gasUsed}`);
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     callResult = await like.transferMultipleDelegated(
       from, addrs, values, maxReward, claimedReward,
       nonce, signature, { from: accounts[1] },
@@ -218,7 +212,7 @@ contract('LikeCoin Gas Estimation', (accounts) => {
     values = [6, 7, 8].map(n => coinsToCoinUnits(n * 100));
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     callResult = await like.transferMultipleDelegated(
       from, addrs, values, maxReward, claimedReward,
       nonce, signature, { from: accounts[1] },
@@ -226,7 +220,7 @@ contract('LikeCoin Gas Estimation', (accounts) => {
     console.log(`transferMultipleDelegated, count = ${addrs.length}, first time gas used = ${callResult.receipt.gasUsed}`);
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     callResult = await like.transferMultipleDelegated(
       from, addrs, values, maxReward, claimedReward,
       nonce, signature, { from: accounts[1] },
@@ -237,7 +231,7 @@ contract('LikeCoin Gas Estimation', (accounts) => {
     values = [9].map(n => coinsToCoinUnits(n * 100));
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     callResult = await like.transferMultipleDelegated(
       from, addrs, values, maxReward, claimedReward,
       nonce, signature, { from: accounts[1] },
@@ -245,7 +239,7 @@ contract('LikeCoin Gas Estimation', (accounts) => {
     console.log(`transferMultipleDelegated, count = ${addrs.length}, first time gas used = ${callResult.receipt.gasUsed}`);
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     callResult = await like.transferMultipleDelegated(
       from, addrs, values, maxReward, claimedReward,
       nonce, signature, { from: accounts[1] },
@@ -280,7 +274,7 @@ contract('LikeCoin Gas Estimation', (accounts) => {
     const claimedReward = 0;
     let nonce = web3Utils.randomHex(32);
     let signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
     let callResult = await like.transferAndCallDelegated(
       from, to, value, data, maxReward, claimedReward,
       nonce, signature, { from: accounts[1] },
@@ -288,7 +282,7 @@ contract('LikeCoin Gas Estimation', (accounts) => {
     console.log(`transferAndCallDelegated, first time gas used = ${callResult.receipt.gasUsed}`);
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
     callResult = await like.transferAndCallDelegated(
       from, to, value, data, maxReward, claimedReward,
       nonce, signature, { from: accounts[1] },

--- a/test/likecoin.js
+++ b/test/likecoin.js
@@ -44,40 +44,34 @@ const typedData = {
   },
 };
 
-function signTransferDelegated(likeAddr, to, value, maxReward, nonce, privKey) {
+function signTransferDelegated(to, value, maxReward, nonce, privKey) {
   const signData = {
-    contractAddr: likeAddr,
-    method: 'transferDelegated',
     to,
-    value: `0x${value.toString(16)}`,
-    maxReward: `0x${maxReward.toString(16)}`,
+    value: value.toFixed(),
+    maxReward: maxReward.toFixed(),
     nonce,
   };
   const sig = ethUtil.ecsign(signHash(typedData.domain, signData, 'TransferDelegatedData'), ethUtil.toBuffer(privKey));
   return ethUtil.toRpcSig(sig.v, sig.r, sig.s);
 }
 
-function signTransferAndCallDelegated(likeAddr, to, value, data, maxReward, nonce, privKey) {
+function signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey) {
   const signData = {
-    contractAddr: likeAddr,
-    method: 'transferAndCallDelegated',
     to,
-    value: `0x${value.toString(16)}`,
+    value: value.toFixed(),
     data,
-    maxReward: `0x${maxReward.toString(16)}`,
+    maxReward: maxReward.toFixed(),
     nonce,
   };
   const sig = ethUtil.ecsign(signHash(typedData.domain, signData, 'TransferAndCallDelegatedData'), ethUtil.toBuffer(privKey));
   return ethUtil.toRpcSig(sig.v, sig.r, sig.s);
 }
 
-function signTransferMultipleDelegated(likeAddr, addrs, values, maxReward, nonce, privKey) {
+function signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey) {
   const signData = {
-    contractAddr: likeAddr,
-    method: 'transferMultipleDelegated',
     addrs,
-    values: values.map(v => `0x${v.toString(16)}`),
-    maxReward: `0x${maxReward.toString(16)}`,
+    values: values.map(v => v.toFixed()),
+    maxReward: maxReward.toFixed(),
     nonce,
   };
   const sig = ethUtil.ecsign(signHash(typedData.domain, signData, 'TransferMultipleDelegatedData'), ethUtil.toBuffer(privKey));
@@ -530,7 +524,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     const claimedReward = maxReward.div(2);
     const nonce = web3Utils.randomHex(32);
     const signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     const caller = accounts[1];
 
     const callResult = await like.transferMultipleDelegated(
@@ -573,7 +567,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     const claimedReward = maxReward.div(2);
     const nonce = web3Utils.randomHex(32);
     const signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
 
     const caller = accounts[1];
     const balanceBeforeCaller = await like.balanceOf(caller);
@@ -599,7 +593,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     let claimedReward = 0;
     let nonce = web3Utils.randomHex(32);
     let signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
 
     const caller = accounts[1];
     await utils.assertSolidityThrow(async () => {
@@ -613,7 +607,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     claimedReward = 1;
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferMultipleDelegated(
         from, addrs, values, maxReward, claimedReward,
@@ -634,7 +628,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     assert(totalValue.add(claimedReward).eq(remaining), 'Total transfer amount is less than remaining, please check test case');
     const nonce = web3Utils.randomHex(32);
     const signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
 
     const caller = accounts[1];
     await like.transferMultipleDelegated(
@@ -652,7 +646,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     const claimedReward = maxReward.sub(1);
     const nonce = web3Utils.randomHex(32);
     const signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
 
     const caller = accounts[2];
     await utils.assertSolidityThrow(async () => {
@@ -672,7 +666,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     const claimedReward = maxReward.sub(1);
     const nonce = web3Utils.randomHex(32);
     const signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
 
     const caller = accounts[2];
     await utils.assertSolidityThrow(async () => {
@@ -692,7 +686,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     let claimedReward = maxReward.add(1);
     let nonce = web3Utils.randomHex(32);
     let signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
 
     const caller = accounts[2];
     await utils.assertSolidityThrow(async () => {
@@ -705,7 +699,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     claimedReward = maxReward;
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     await like.transferMultipleDelegated(
       from, addrs, values, maxReward, claimedReward,
       nonce, signature, { from: caller },
@@ -714,7 +708,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     claimedReward = 0;
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     await like.transferMultipleDelegated(
       from, addrs, values, maxReward, claimedReward,
       nonce, signature, { from: caller },
@@ -724,7 +718,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     claimedReward = 0;
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     await like.transferMultipleDelegated(
       from, addrs, values, maxReward, claimedReward,
       nonce, signature, { from: caller },
@@ -740,21 +734,12 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     const claimedReward = maxReward.sub(1);
     const caller = accounts[2];
 
-    const anotherLike = await LikeCoin.new(0, accounts[9], sigChecker.address);
     let nonce = web3Utils.randomHex(32);
-    let signature =
-      signTransferMultipleDelegated(anotherLike.address, addrs, values, maxReward, nonce, privKey);
-    await utils.assertSolidityThrow(async () => {
-      await like.transferMultipleDelegated(
-        from, addrs, values, maxReward, claimedReward,
-        nonce, signature, { from: caller },
-      );
-    }, 'should forbid transferring with signature for different contract address');
 
     const anotherAddrs = [2, 3, 5].map(i => accounts[i]);
     nonce = web3Utils.randomHex(32);
-    signature =
-      signTransferMultipleDelegated(like.address, anotherAddrs, values, maxReward, nonce, privKey);
+    let signature =
+      signTransferMultipleDelegated(anotherAddrs, values, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferMultipleDelegated(
         from, addrs, values, maxReward, claimedReward,
@@ -765,7 +750,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     const anotherValues = [201, 300, 400];
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, anotherValues, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, anotherValues, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferMultipleDelegated(
         from, addrs, values, maxReward, claimedReward,
@@ -775,7 +760,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
 
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward.add(1), nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward.add(1), nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferMultipleDelegated(
         from, addrs, values, maxReward, claimedReward,
@@ -785,7 +770,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
 
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferMultipleDelegated(
         from, addrs, values, maxReward, claimedReward,
@@ -795,7 +780,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
 
     nonce = web3Utils.randomHex(32);
     signature = signTransferMultipleDelegated(
-      like.address, addrs, values, maxReward,
+      addrs, values, maxReward,
       nonce, Accounts[0].secretKey,
     );
     await utils.assertSolidityThrow(async () => {
@@ -815,7 +800,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
 
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     await like.transferMultipleDelegated(
       from, addrs, values, maxReward, claimedReward,
       nonce, signature, { from: caller },
@@ -831,7 +816,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
     const claimedReward = maxReward.sub(1);
     const nonce = web3Utils.randomHex(32);
     let signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
 
     const caller = accounts[2];
     await like.transferMultipleDelegated(
@@ -847,7 +832,7 @@ contract('LikeCoin transferMultipleDelegated', (accounts) => {
 
     values = [2, 3, 4];
     signature =
-      signTransferMultipleDelegated(like.address, addrs, values, maxReward, nonce, privKey);
+      signTransferMultipleDelegated(addrs, values, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferMultipleDelegated(
         from, addrs, values, maxReward, claimedReward,
@@ -875,7 +860,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
     const maxReward = coinsToCoinUnits(1);
     const claimedReward = maxReward.sub(1);
     const nonce = web3Utils.randomHex(32);
-    const signature = signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+    const signature = signTransferDelegated(to, value, maxReward, nonce, privKey);
     const caller = accounts[2];
 
     const callResult = await like.transferDelegated(
@@ -911,7 +896,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
 
     let claimedReward = 0;
     let nonce = web3Utils.randomHex(32);
-    let signature = signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+    let signature = signTransferDelegated(to, value, maxReward, nonce, privKey);
 
     const caller = accounts[2];
     await utils.assertSolidityThrow(async () => {
@@ -924,7 +909,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
     value = value.sub(1);
     claimedReward = 1;
     nonce = web3Utils.randomHex(32);
-    signature = signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+    signature = signTransferDelegated(to, value, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferDelegated(
         from, to, value, maxReward, claimedReward,
@@ -941,7 +926,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
     const maxReward = coinsToCoinUnits(1);
     const claimedReward = 1;
     const nonce = web3Utils.randomHex(32);
-    const signature = signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+    const signature = signTransferDelegated(to, value, maxReward, nonce, privKey);
 
     const caller = accounts[2];
     await like.transferDelegated(
@@ -962,7 +947,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
 
     let claimedReward = maxReward.add(1);
     let nonce = web3Utils.randomHex(32);
-    let signature = signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+    let signature = signTransferDelegated(to, value, maxReward, nonce, privKey);
 
     const caller = accounts[2];
     await utils.assertSolidityThrow(async () => {
@@ -974,7 +959,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
 
     claimedReward = maxReward;
     nonce = web3Utils.randomHex(32);
-    signature = signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+    signature = signTransferDelegated(to, value, maxReward, nonce, privKey);
     await like.transferDelegated(
       from, to, value, maxReward, claimedReward,
       nonce, signature, { from: caller },
@@ -982,7 +967,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
 
     claimedReward = 0;
     nonce = web3Utils.randomHex(32);
-    signature = signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+    signature = signTransferDelegated(to, value, maxReward, nonce, privKey);
     await like.transferDelegated(
       from, to, value, maxReward, claimedReward,
       nonce, signature, { from: caller },
@@ -991,7 +976,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
     maxReward = 0;
     claimedReward = 0;
     nonce = web3Utils.randomHex(32);
-    signature = signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+    signature = signTransferDelegated(to, value, maxReward, nonce, privKey);
     await like.transferDelegated(
       from, to, value, maxReward, claimedReward,
       nonce, signature, { from: caller },
@@ -1007,21 +992,12 @@ contract('LikeCoin transferDelegated', (accounts) => {
     const claimedReward = maxReward.sub(1);
     const caller = accounts[2];
 
-    const anotherLike = await LikeCoin.new(0, accounts[9], sigChecker.address);
     let nonce = web3Utils.randomHex(32);
-    let signature =
-      signTransferDelegated(anotherLike.address, to, value, maxReward, nonce, privKey);
-    await utils.assertSolidityThrow(async () => {
-      await like.transferDelegated(
-        from, to, value, maxReward, claimedReward,
-        nonce, signature, { from: caller },
-      );
-    }, 'should forbid transferring with signature for different contract address');
 
     const anotherTo = accounts[3];
     nonce = web3Utils.randomHex(32);
-    signature =
-      signTransferDelegated(like.address, anotherTo, value, maxReward, nonce, privKey);
+    let signature =
+      signTransferDelegated(anotherTo, value, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferDelegated(
         from, to, value, maxReward, claimedReward,
@@ -1032,7 +1008,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
     const anotherValue = 2;
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferDelegated(like.address, to, anotherValue, maxReward, nonce, privKey);
+      signTransferDelegated(to, anotherValue, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferDelegated(
         from, to, value, maxReward, claimedReward,
@@ -1042,7 +1018,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
 
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferDelegated(like.address, to, value, maxReward.add(1), nonce, privKey);
+      signTransferDelegated(to, value, maxReward.add(1), nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferDelegated(
         from, to, value, maxReward, claimedReward,
@@ -1052,7 +1028,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
 
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+      signTransferDelegated(to, value, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferDelegated(
         from, to, value, maxReward, claimedReward,
@@ -1062,7 +1038,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
 
     nonce = web3Utils.randomHex(32);
     signature = signTransferDelegated(
-      like.address, to, value, maxReward,
+      to, value, maxReward,
       nonce, Accounts[1].secretKey,
     );
     await utils.assertSolidityThrow(async () => {
@@ -1082,7 +1058,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
 
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+      signTransferDelegated(to, value, maxReward, nonce, privKey);
     await like.transferDelegated(
       from, to, value, maxReward, claimedReward,
       nonce, signature, { from: caller },
@@ -1099,7 +1075,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
     const caller = accounts[2];
     const nonce = web3Utils.randomHex(32);
     let signature =
-      signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+      signTransferDelegated(to, value, maxReward, nonce, privKey);
 
     await like.transferDelegated(
       from, to, value, maxReward, claimedReward,
@@ -1114,7 +1090,7 @@ contract('LikeCoin transferDelegated', (accounts) => {
 
     value = 2;
     signature =
-      signTransferDelegated(like.address, to, value, maxReward, nonce, privKey);
+      signTransferDelegated(to, value, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferDelegated(
         from, to, value, maxReward, claimedReward,
@@ -1147,7 +1123,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
     const claimedReward = maxReward.sub(1);
     const nonce = web3Utils.randomHex(32);
     const signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
     const caller = accounts[1];
 
     const callResult = await like.transferAndCallDelegated(
@@ -1192,7 +1168,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
     let claimedReward = 0;
     let nonce = web3Utils.randomHex(32);
     let signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
 
     const caller = accounts[1];
     await utils.assertSolidityThrow(async () => {
@@ -1206,7 +1182,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
     claimedReward = 1;
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferAndCallDelegated(
         from, to, value, data, maxReward, claimedReward,
@@ -1225,7 +1201,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
     const claimedReward = 1;
     const nonce = web3Utils.randomHex(32);
     const signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
 
     const caller = accounts[1];
     await like.transferAndCallDelegated(
@@ -1249,7 +1225,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
 
     let nonce = web3Utils.randomHex(32);
     let signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
     const caller = accounts[1];
 
     await utils.assertSolidityThrow(async () => {
@@ -1271,7 +1247,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
 
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
     await like.removeTransferAndCallWhitelist(mock.address, { from: accounts[0] });
     await utils.assertSolidityThrow(async () => {
       await like.transferAndCallDelegated(
@@ -1330,7 +1306,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
     const claimedReward = 1;
     const nonce = web3Utils.randomHex(32);
     const signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
 
     const caller = accounts[1];
     await utils.assertSolidityThrow(async () => {
@@ -1352,7 +1328,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
     let claimedReward = maxReward.add(1);
     let nonce = web3Utils.randomHex(32);
     let signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
 
     const caller = accounts[1];
     await utils.assertSolidityThrow(async () => {
@@ -1365,7 +1341,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
     claimedReward = maxReward;
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
     await like.transferAndCallDelegated(
       from, to, value, data, maxReward, claimedReward,
       nonce, signature, { from: caller },
@@ -1374,7 +1350,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
     claimedReward = 0;
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
     await like.transferAndCallDelegated(
       from, to, value, data, maxReward, claimedReward,
       nonce, signature, { from: caller },
@@ -1384,7 +1360,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
     claimedReward = 0;
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
     await like.transferAndCallDelegated(
       from, to, value, data, maxReward, claimedReward,
       nonce, signature, { from: caller },
@@ -1401,22 +1377,13 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
     const claimedReward = maxReward.sub(1);
     const caller = accounts[1];
 
-    const anotherLike = await LikeCoin.new(0, accounts[9], sigChecker.address);
     let nonce = web3Utils.randomHex(32);
-    let signature =
-      signTransferAndCallDelegated(anotherLike.address, to, value, data, maxReward, nonce, privKey);
-    await utils.assertSolidityThrow(async () => {
-      await like.transferAndCallDelegated(
-        from, to, value, data, maxReward, claimedReward,
-        nonce, signature, { from: caller },
-      );
-    }, 'should forbid transferring with signature for different contract address');
 
     const anotherMock = await TransferAndCallReceiverMock.new(like.address);
     const anotherTo = anotherMock.address;
     nonce = web3Utils.randomHex(32);
-    signature =
-      signTransferAndCallDelegated(like.address, anotherTo, value, data, maxReward, nonce, privKey);
+    let signature =
+      signTransferAndCallDelegated(anotherTo, value, data, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferAndCallDelegated(
         from, to, value, data, maxReward, claimedReward,
@@ -1427,7 +1394,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
     const anotherValue = 2;
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferAndCallDelegated(like.address, to, anotherValue, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, anotherValue, data, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferAndCallDelegated(
         from, to, value, data, maxReward, claimedReward,
@@ -1438,7 +1405,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
     const anotherData = '0x1338133813381338133813381338133813381338133813381338133813381338';
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferAndCallDelegated(like.address, to, value, anotherData, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, anotherData, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferAndCallDelegated(
         from, to, value, data, maxReward, claimedReward,
@@ -1448,7 +1415,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
 
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward.add(1), nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward.add(1), nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferAndCallDelegated(
         from, to, value, data, maxReward, claimedReward,
@@ -1458,7 +1425,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
 
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferAndCallDelegated(
         from, to, value, data, maxReward, claimedReward,
@@ -1468,7 +1435,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
 
     nonce = web3Utils.randomHex(32);
     signature = signTransferAndCallDelegated(
-      like.address, to, value, data, maxReward,
+      to, value, data, maxReward,
       nonce, Accounts[1].secretKey,
     );
     await utils.assertSolidityThrow(async () => {
@@ -1488,7 +1455,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
 
     nonce = web3Utils.randomHex(32);
     signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
     await like.transferAndCallDelegated(
       from, to, value, data, maxReward, claimedReward,
       nonce, signature, { from: caller },
@@ -1506,7 +1473,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
     const caller = accounts[1];
     const nonce = web3Utils.randomHex(32);
     let signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
 
     await like.transferAndCallDelegated(
       from, to, value, data, maxReward, claimedReward,
@@ -1521,7 +1488,7 @@ contract('LikeCoin transferAndCallDelegated', (accounts) => {
 
     value = 2;
     signature =
-      signTransferAndCallDelegated(like.address, to, value, data, maxReward, nonce, privKey);
+      signTransferAndCallDelegated(to, value, data, maxReward, nonce, privKey);
     await utils.assertSolidityThrow(async () => {
       await like.transferAndCallDelegated(
         from, to, value, data, maxReward, claimedReward,
@@ -1560,7 +1527,7 @@ contract('LikeCoin delegated switch', (accounts) => {
 
     const transferNonce = web3Utils.randomHex(32);
     const transferSignature = signTransferDelegated(
-      like.address, to, value, maxReward,
+      to, value, maxReward,
       transferNonce, privKey,
     );
     await utils.assertSolidityThrow(async () => {
@@ -1572,7 +1539,7 @@ contract('LikeCoin delegated switch', (accounts) => {
 
     const transferMultipleNonce = web3Utils.randomHex(32);
     const transferMultipleSignature = signTransferMultipleDelegated(
-      like.address, addrs, values, maxReward,
+      addrs, values, maxReward,
       transferMultipleNonce, privKey,
     );
     await utils.assertSolidityThrow(async () => {
@@ -1584,7 +1551,7 @@ contract('LikeCoin delegated switch', (accounts) => {
 
     const transferAndCallNonce = web3Utils.randomHex(32);
     const transferAndCallSignature = signTransferAndCallDelegated(
-      like.address, to, value, data, maxReward,
+      to, value, data, maxReward,
       transferAndCallNonce, privKey,
     );
     await utils.assertSolidityThrow(async () => {
@@ -1671,19 +1638,19 @@ contract('LikeCoin Signature Owner', (accounts) => {
 
     const transferNonce = web3Utils.randomHex(32);
     const transferSignature = signTransferDelegated(
-      like.address, to, value, maxReward,
+      to, value, maxReward,
       transferNonce, privKey,
     );
 
     const transferMultipleNonce = web3Utils.randomHex(32);
     const transferMultipleSignature = signTransferMultipleDelegated(
-      like.address, addrs, values, maxReward,
+      addrs, values, maxReward,
       transferMultipleNonce, privKey,
     );
 
     const transferAndCallNonce = web3Utils.randomHex(32);
     const transferAndCallSignature = signTransferAndCallDelegated(
-      like.address, to, value, data, maxReward,
+      to, value, data, maxReward,
       transferAndCallNonce, privKey,
     );
 

--- a/test/likecoin.js
+++ b/test/likecoin.js
@@ -25,6 +25,7 @@ const BigNumber = require('bignumber.js');
 const web3Utils = require('web3-utils');
 const AccountLib = require('eth-lib/lib/account');
 const Accounts = require('./accounts.json');
+const ethUtil = require('ethereumjs-util');
 
 const LikeCoin = artifacts.require('./LikeCoin.sol');
 const SignatureCheckerImpl = artifacts.require('./SignatureCheckerImpl.sol');
@@ -33,7 +34,16 @@ const TransferAndCallReceiverMock = artifacts.require('./TransferAndCallReceiver
 const ContributorPool = artifacts.require('./ContributorPool.sol');
 const CreatorsPool = artifacts.require('./CreatorsPool.sol');
 
-const { coinsToCoinUnits } = utils;
+const { coinsToCoinUnits, signHash } = utils;
+
+const typedData = {
+  domain: {
+    name: 'LikeCoin',
+    version: '1',
+    chainId: 1,
+    verifyingContract: '0x02F61Fd266DA6E8B102D4121f5CE7b992640CF98',
+  },
+};
 
 function signTypedCall(signData, privKey) {
   const paramSignatures = signData.map(item => ({ type: 'string', value: `${item.type} ${item.name}` }));
@@ -46,40 +56,43 @@ function signTypedCall(signData, privKey) {
 }
 
 function signTransferDelegated(likeAddr, to, value, maxReward, nonce, privKey) {
-  const signData = [
-    { type: 'address', name: 'contract', value: likeAddr },
-    { type: 'string', name: 'method', value: 'transferDelegated' },
-    { type: 'address', name: 'to', value: to },
-    { type: 'uint256', name: 'value', value },
-    { type: 'uint256', name: 'maxReward', value: maxReward },
-    { type: 'uint256', name: 'nonce', value: nonce },
-  ];
-  return signTypedCall(signData, privKey);
+  const signData = {
+    contractAddr: likeAddr,
+    method: 'transferDelegated',
+    to,
+    value: `0x${value.toString(16)}`,
+    maxReward: `0x${maxReward.toString(16)}`,
+    nonce,
+  };
+  const sig = ethUtil.ecsign(signHash(typedData.domain, signData, 'TransferDelegatedData'), ethUtil.toBuffer(privKey));
+  return ethUtil.toRpcSig(sig.v, sig.r, sig.s);
 }
 
 function signTransferAndCallDelegated(likeAddr, to, value, data, maxReward, nonce, privKey) {
-  const signData = [
-    { type: 'address', name: 'contract', value: likeAddr },
-    { type: 'string', name: 'method', value: 'transferAndCallDelegated' },
-    { type: 'address', name: 'to', value: to },
-    { type: 'uint256', name: 'value', value },
-    { type: 'bytes', name: 'data', value: data },
-    { type: 'uint256', name: 'maxReward', value: maxReward },
-    { type: 'uint256', name: 'nonce', value: nonce },
-  ];
-  return signTypedCall(signData, privKey);
+  const signData = {
+    contractAddr: likeAddr,
+    method: 'transferAndCallDelegated',
+    to,
+    value: `0x${value.toString(16)}`,
+    data,
+    maxReward: `0x${maxReward.toString(16)}`,
+    nonce,
+  };
+  const sig = ethUtil.ecsign(signHash(typedData.domain, signData, 'TransferAndCallDelegatedData'), ethUtil.toBuffer(privKey));
+  return ethUtil.toRpcSig(sig.v, sig.r, sig.s);
 }
 
 function signTransferMultipleDelegated(likeAddr, addrs, values, maxReward, nonce, privKey) {
-  const signData = [
-    { type: 'address', name: 'contract', value: likeAddr },
-    { type: 'string', name: 'method', value: 'transferMultipleDelegated' },
-    { type: 'address[]', name: 'addrs', value: addrs },
-    { type: 'uint256[]', name: 'values', value: values },
-    { type: 'uint256', name: 'maxReward', value: maxReward },
-    { type: 'uint256', name: 'nonce', value: nonce },
-  ];
-  return signTypedCall(signData, privKey);
+  const signData = {
+    contractAddr: likeAddr,
+    method: 'transferMultipleDelegated',
+    addrs,
+    values: values.map(v => `0x${v.toString(16)}`),
+    maxReward: `0x${maxReward.toString(16)}`,
+    nonce,
+  };
+  const sig = ethUtil.ecsign(signHash(typedData.domain, signData, 'TransferMultipleDelegatedData'), ethUtil.toBuffer(privKey));
+  return ethUtil.toRpcSig(sig.v, sig.r, sig.s);
 }
 
 contract('LikeCoin Basic', (accounts) => {

--- a/test/likecoin.js
+++ b/test/likecoin.js
@@ -23,7 +23,6 @@
 const utils = require('./utils.js');
 const BigNumber = require('bignumber.js');
 const web3Utils = require('web3-utils');
-const AccountLib = require('eth-lib/lib/account');
 const Accounts = require('./accounts.json');
 const ethUtil = require('ethereumjs-util');
 
@@ -44,16 +43,6 @@ const typedData = {
     verifyingContract: '0x02F61Fd266DA6E8B102D4121f5CE7b992640CF98',
   },
 };
-
-function signTypedCall(signData, privKey) {
-  const paramSignatures = signData.map(item => ({ type: 'string', value: `${item.type} ${item.name}` }));
-  const params = signData.map(item => ({ type: item.type, value: item.value }));
-  const hash = web3Utils.soliditySha3(
-    { type: 'bytes32', value: web3Utils.soliditySha3(...paramSignatures) },
-    { type: 'bytes32', value: web3Utils.soliditySha3(...params) },
-  );
-  return AccountLib.sign(hash, privKey);
-}
 
 function signTransferDelegated(likeAddr, to, value, maxReward, nonce, privKey) {
   const signData = {

--- a/test/utils.js
+++ b/test/utils.js
@@ -123,129 +123,129 @@ function coinsToCoinUnits(value) {
 }
 
 const types = {
-    EIP712Domain: [
-        { name: 'name', type: 'string' },
-        { name: 'version', type: 'string' },
-        { name: 'chainId', type: 'uint256' },
-        { name: 'verifyingContract', type: 'address' },
-    ],
-    TransferDelegatedData: [
-        { name: 'contractAddr', type: 'address' },
-        { name: 'method', type: 'string' },
-        { name: 'to', type: 'address' },
-        { name: 'value', type: 'uint256' },
-        { name: 'maxReward', type: 'uint256' }, 
-        { name: 'nonce', type: 'uint256' },
-    ],
-    TransferAndCallDelegatedData: [
-        { name: 'contractAddr', type: 'address' },
-        { name: 'method', type: 'string' },
-        { name: 'to', type: 'address' },
-        { name: 'value', type: 'uint256' },
-        { name: 'data', type: 'bytes' },
-        { name: 'maxReward', type: 'uint256' }, 
-        { name: 'nonce', type: 'uint256' },
-    ],
-    TransferMultipleDelegatedData: [
-        { name: 'contractAddr', type: 'address' },
-        { name: 'method', type: 'string' },
-        { name: 'addrs', type: 'address[]' },
-        { name: 'values', type: 'uint256[]' },
-        { name: 'maxReward', type: 'uint256' }, 
-        { name: 'nonce', type: 'uint256' },
-    ],
+  EIP712Domain: [
+    { name: 'name', type: 'string' },
+    { name: 'version', type: 'string' },
+    { name: 'chainId', type: 'uint256' },
+    { name: 'verifyingContract', type: 'address' },
+  ],
+  TransferDelegatedData: [
+    { name: 'contractAddr', type: 'address' },
+    { name: 'method', type: 'string' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'maxReward', type: 'uint256' },
+    { name: 'nonce', type: 'uint256' },
+  ],
+  TransferAndCallDelegatedData: [
+    { name: 'contractAddr', type: 'address' },
+    { name: 'method', type: 'string' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'data', type: 'bytes' },
+    { name: 'maxReward', type: 'uint256' },
+    { name: 'nonce', type: 'uint256' },
+  ],
+  TransferMultipleDelegatedData: [
+    { name: 'contractAddr', type: 'address' },
+    { name: 'method', type: 'string' },
+    { name: 'addrs', type: 'address[]' },
+    { name: 'values', type: 'uint256[]' },
+    { name: 'maxReward', type: 'uint256' },
+    { name: 'nonce', type: 'uint256' },
+  ],
 };
 
 // Recursively finds all the dependencies of a type
 function dependencies(primaryType, found = []) {
-    if (found.includes(primaryType)) {
-        return found;
-    }
-    if (types[primaryType] === undefined) {
-        return found;
-    }
-    found.push(primaryType);
-    for (let field of types[primaryType]) {
-        for (let dep of dependencies(field.type, found)) {
-            if (!found.includes(dep)) {
-                found.push(dep);
-            }
-        }
-    }
+  if (found.includes(primaryType)) {
     return found;
+  }
+  if (types[primaryType] === undefined) {
+    return found;
+  }
+  found.push(primaryType);
+  types[primaryType].forEach((field) => {
+    dependencies(field.type, found).forEach((dep) => {
+      if (!found.includes(dep)) {
+        found.push(dep);
+      }
+    });
+  });
+  return found;
 }
 
 function encodeType(primaryType) {
-    // Get dependencies primary first, then alphabetical
-    let deps = dependencies(primaryType);
-    deps = deps.filter(t => t != primaryType);
-    deps = [primaryType].concat(deps.sort());
+  // Get dependencies primary first, then alphabetical
+  let deps = dependencies(primaryType);
+  deps = deps.filter(t => t !== primaryType);
+  deps = [primaryType].concat(deps.sort());
 
-    // Format as a string with fields
-    let result = '';
-    for (let type of deps) {
-        result += `${type}(${types[type].map(({ name, type }) => `${type} ${name}`).join(',')})`;
-    }
-    return result;
+  // Format as a string with fields
+  let result = '';
+  deps.forEach((type) => {
+    result += `${type}(${types[type].map(({ name, type: t }) => `${t} ${name}`).join(',')})`;
+  });
+  return result;
 }
 
 function typeHash(primaryType) {
-    return ethUtil.sha3(encodeType(primaryType));
+  return ethUtil.sha3(encodeType(primaryType));
 }
 
 function encodeData(primaryType, data) {
-    let encTypes = [];
-    let encValues = [];
+  const encTypes = [];
+  const encValues = [];
 
-    // Add typehash
-    encTypes.push('bytes32');
-    encValues.push(typeHash(primaryType));
+  // Add typehash
+  encTypes.push('bytes32');
+  encValues.push(typeHash(primaryType));
 
-    // Add field contents
-    for (let field of types[primaryType]) {
-        let value = data[field.name];
-        if (field.type == 'string' || field.type == 'bytes') {
-            encTypes.push('bytes32');
-            value = ethUtil.sha3(value);
-            encValues.push(value);
-        } else if (types[field.type] !== undefined) {
-            encTypes.push('bytes32');
-            value = ethUtil.sha3(encodeData(field.type, value));
-            encValues.push(value);
-        } else if (field.type.lastIndexOf(']') === field.type.length - 1) {
-            // array field
-			encTypes.push('bytes32');
-            const parsedType = field.type.slice(0, field.type.lastIndexOf('['));
-            if (types[parsedType] !== undefined) {
-              value = ethUtil.sha3(value.map(item => encodeData(parsedType, item)).join(''));
-            } else {
-              const arrayTypes = new Array(value.length);
-              arrayTypes.fill(parsedType);
-              value = ethUtil.sha3(abi.rawEncode(arrayTypes, value));
-            }
-			encValues.push(value);
-            // throw 'TODO: Arrays currently unimplemented in encodeData';
-        } else {
-            encTypes.push(field.type);
-            encValues.push(value);
+  // Add field contents
+  types[primaryType].forEach((field) => {
+    let value = data[field.name];
+    if (field.type === 'string' || field.type === 'bytes') {
+      encTypes.push('bytes32');
+      value = ethUtil.sha3(value);
+      encValues.push(value);
+    } else if (types[field.type] !== undefined) {
+      encTypes.push('bytes32');
+      value = ethUtil.sha3(encodeData(field.type, value));
+      encValues.push(value);
+    } else if (field.type.lastIndexOf(']') === field.type.length - 1) {
+      // array field
+      encTypes.push('bytes32');
+      const parsedType = field.type.slice(0, field.type.lastIndexOf('['));
+      if (types[parsedType] !== undefined) {
+        value = ethUtil.sha3(value.map(item => encodeData(parsedType, item)).join(''));
+      } else {
+        const arrayTypes = new Array(value.length);
+        arrayTypes.fill(parsedType);
+        if (parsedType === 'string' || parsedType === 'bytes') {
+          value = value.map(v => ethUtil.sha3(v));
         }
+        value = ethUtil.sha3(abi.rawEncode(arrayTypes, value));
+      }
+      encValues.push(value);
+    } else {
+      encTypes.push(field.type);
+      encValues.push(value);
     }
+  });
 
-    return abi.rawEncode(encTypes, encValues);
+  return abi.rawEncode(encTypes, encValues);
 }
 
 function structHash(primaryType, data) {
-    return ethUtil.sha3(encodeData(primaryType, data));
+  return ethUtil.sha3(encodeData(primaryType, data));
 }
 
 function signHash(domainData, data, primaryType) {
-    return ethUtil.sha3(
-        Buffer.concat([
-            Buffer.from('1901', 'hex'),
-            structHash('EIP712Domain', domainData),
-            structHash(primaryType, data),
-        ]),
-    );
+  return ethUtil.sha3(Buffer.concat([
+    Buffer.from('1901', 'hex'),
+    structHash('EIP712Domain', domainData),
+    structHash(primaryType, data),
+  ]));
 }
 
 module.exports = {

--- a/test/utils.js
+++ b/test/utils.js
@@ -130,16 +130,12 @@ const types = {
     { name: 'verifyingContract', type: 'address' },
   ],
   TransferDelegatedData: [
-    { name: 'contractAddr', type: 'address' },
-    { name: 'method', type: 'string' },
     { name: 'to', type: 'address' },
     { name: 'value', type: 'uint256' },
     { name: 'maxReward', type: 'uint256' },
     { name: 'nonce', type: 'uint256' },
   ],
   TransferAndCallDelegatedData: [
-    { name: 'contractAddr', type: 'address' },
-    { name: 'method', type: 'string' },
     { name: 'to', type: 'address' },
     { name: 'value', type: 'uint256' },
     { name: 'data', type: 'bytes' },
@@ -147,8 +143,6 @@ const types = {
     { name: 'nonce', type: 'uint256' },
   ],
   TransferMultipleDelegatedData: [
-    { name: 'contractAddr', type: 'address' },
-    { name: 'method', type: 'string' },
     { name: 'addrs', type: 'address[]' },
     { name: 'values', type: 'uint256[]' },
     { name: 'maxReward', type: 'uint256' },


### PR DESCRIPTION
Currently LikeChain related contracts are inside `likechain-contracts`, since we don't have test cases yet and truffle still doesn't support solidity v0.4.25